### PR TITLE
Change API to fix iOS10 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The values are swatches (possibly `null`) or with the fields defined below.
 
 ### Swatch Fields
 
-Colors include alpha in the `react-native`  `rgba(255,255,255,255)` format. Note that on iOS10 devices UIExtendedSRGBColorSpace color values may be greater than 255 or less than 0, but they will render correctly on the device.
+Colors include alpha in the `react-native`  `rgba(255,255,255,1.0)` format. Note that on iOS10 devices UIExtendedSRGBColorSpace color values may be greater than 255 or less than 0, but they will render correctly on the device.
 
 Field | Info
 ------ | ----

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ There are two properties and they're valid for iOS only. On Android, this parame
 Property | Type | Info
 -------- | ---- | ----
 `threshold` | Float | Determines whether white or black text will be selected to contrast with the selected color. It is the value for `L`, in the complex formula at the end of this [StackOverflow comment](http://stackoverflow.com/a/3943023/1404185). The default value is 0.179.
-`quality` | String | One of "low", "medium", or "high". Higher quality extracts more colors, takes more time and consumes more memory.
+`quality` | String | One of "low", "medium", or "high". Higher quality extracts more colors, takes more time and consumes more memory. Default is "low".
 
 #### image
 A path to an image such as that returned by [`react-native-image-picker`](https://github.com/marcshilling/react-native-image-picker). For iOS use the `origURL` field of the image picker response, because only images from `assets-library://` have been tested. For Android use the `path` field.
@@ -78,7 +78,7 @@ The values are swatches (possibly `null`) or with the fields defined below.
 
 ### Swatch Fields
 
-Colors include alpha in the `react-native`  `rgba(255,255,255,255)` format.
+Colors include alpha in the `react-native`  `rgba(255,255,255,255)` format. Note that on iOS10 devices UIExtendedSRGBColorSpace color values may be greater than 255 or less than 0, but they will render correctly on the device.
 
 Field | Info
 ------ | ----

--- a/README.md
+++ b/README.md
@@ -4,11 +4,6 @@ A React-Native library which on Android, wraps the [Android Pallete Class](https
 
  A small example app is included.
 
-## iOS10 Compatability Warning
-**This code currently fails on iOS10 devices if built with an iOS10 SDK.** See [this issue](https://github.com/bsudekum/react-native-color-grabber/issues/2). Note that in `react-native-color-grabber` the component returns wrong results, but in this API an error is returned.
-
-The easiest workaround is to build on XCode 7. That build will work on iOS10 devices.
-
 ## Getting started
 
 `$ npm install react-native-palette --save`
@@ -44,7 +39,13 @@ The easiest workaround is to build on XCode 7. That build will work on iOS10 dev
 ### `getAllSwatches(options, image, (error, swatches) => {})`
 
 #### options
-An object containing option properties. Currently the only supported property is `threshold`, valid for iOS only, which determines whether white or black text will be selected to contrast with the selected color. It is the value for `L`, in the complex formula at the end of this [StackOverflow comment](http://stackoverflow.com/a/3943023/1404185). The default value is 0.179.
+An object containing option properties.
+There are two properties and they're valid for iOS only. On Android, this parameter is ignored.
+
+Property | Type | Info
+-------- | ---- | ----
+`threshold` | Float | Determines whether white or black text will be selected to contrast with the selected color. It is the value for `L`, in the complex formula at the end of this [StackOverflow comment](http://stackoverflow.com/a/3943023/1404185). The default value is 0.179.
+`quality` | String | One of "low", "medium", or "high". Higher quality extracts more colors, takes more time and consumes more memory.
 
 #### image
 A path to an image such as that returned by [`react-native-image-picker`](https://github.com/marcshilling/react-native-image-picker). For iOS use the `origURL` field of the image picker response, because only images from `assets-library://` have been tested. For Android use the `path` field.
@@ -77,7 +78,7 @@ The values are swatches (possibly `null`) or with the fields defined below.
 
 ### Swatch Fields
 
-Colors include alpha in the `react-native` hexadecimal `#rrggbbaa` format.
+Colors include alpha in the `react-native`  `rgba(255,255,255,255)` format.
 
 Field | Info
 ------ | ----

--- a/android/src/main/java/io/palette/RNPaletteModule.java
+++ b/android/src/main/java/io/palette/RNPaletteModule.java
@@ -2,6 +2,7 @@ package io.palette;
 
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.Color;
 import android.graphics.BitmapFactory.Options;
 import android.support.v7.graphics.Palette;
 import android.support.v7.graphics.Palette.Swatch;
@@ -32,13 +33,8 @@ public class RNPaletteModule extends ReactContextBaseJavaModule {
     return "RNPalette";
   }
 
-  private String intToRGB(int color) {
-    return String.format("#%06X", (0xFFFFFF & color));
-  }
-
   private String intToRGBA(int color) {
-    color = Integer.rotateLeft(color, 8);
-    return String.format("#%08X", (0xFFFFFFFF & color));
+    return String.format("rgba(%d,%d,%d,%d)", Color.red(color), Color.green(color), Color.blue(color), Color.alpha(color));
   }
 
   private Palette getPallet(final String realPath, final Callback callback) {

--- a/android/src/main/java/io/palette/RNPaletteModule.java
+++ b/android/src/main/java/io/palette/RNPaletteModule.java
@@ -34,7 +34,7 @@ public class RNPaletteModule extends ReactContextBaseJavaModule {
   }
 
   private String intToRGBA(int color) {
-    return String.format("rgba(%d,%d,%d,%d)", Color.red(color), Color.green(color), Color.blue(color), Color.alpha(color));
+    return String.format("rgba(%d,%d,%d,%.3f)", Color.red(color), Color.green(color), Color.blue(color), (float)(Color.alpha(color))/255.0);
   }
 
   private Palette getPallet(final String realPath, final Callback callback) {

--- a/example/components/sample.js
+++ b/example/components/sample.js
@@ -60,7 +60,7 @@ export default Sample = React.createClass( {
   },
 
   render() {
-    console.log(this.state.colors);
+    //console.log(this.state.colors);
     let isImage = this.state.colors && this.state.colors.image;
     let buttonText = `Load ${isImage? "Another":""} Image`
     let textColor = this.state.colors && this.state.colors.swatches && this.state.colors.swatches[0].bodyTextColor  ? this.state.colors.swatches[0].bodyTextColor : 'white'

--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,7 @@
     "react": "15.4.1",
     "react-native": "0.40.0",
     "react-native-image-picker": "^0.24.1",
-    "react-native-palette": "https://github.com/chetstone/react-native-palette"
+    "react-native-palette": "*"
   },
   "devDependencies": {
     "babel-jest": "18.0.0",

--- a/example/utils/ImagePicker.js
+++ b/example/utils/ImagePicker.js
@@ -30,6 +30,9 @@ export default function(storeImage, useNamed) {
     maxHeight: max|0,
   };
 
+
+  let pickOptions = {quality: "low"};
+
   //console.log("In ImagePicker");
   ImagePicker.launchImageLibrary(options, (response) => {
     var colors = {};
@@ -61,7 +64,7 @@ export default function(storeImage, useNamed) {
           storeImage(colors);
         });
       } else {
-        getAllSwatches({}, path, (error, swatches) => {
+        getAllSwatches(pickOptions, path, (error, swatches) => {
           if ( error) {
             console.log(error);
             colors.swatches = error;

--- a/index.js
+++ b/index.js
@@ -5,6 +5,14 @@ const { RNPalette } = NativeModules;
 
 var Threshold = 0.179; // contrast luminosity. Original formula calls for 0.179
 
+var iOSOptions = {
+low: { dimension: 5, flexibility: 5, range: 40 },
+medium: { dimension: 8, flexibility: 5, range: 40 },
+high: { dimension: 10, flexibility: 10, range: 30 }
+};
+
+let quality = "low"
+
 function toHex(d) {
   return  ("0"+(Math.round(d).toString(16))).slice(-2).toUpperCase()
 }
@@ -45,9 +53,14 @@ export const getAllSwatches = (options, image, callback) => {
     return RNPalette.getAllSwatches(image, callback);
   }
   if (options.hasOwnProperty('threshold')) {
-    Threshold = options.threshold
+    Threshold = options.threshold;
   }
-  RNPalette.getColors(image, (err, res) => {
+
+  if (options.hasOwnProperty('quality')) {
+    quality = options.quality
+  }
+
+  RNPalette.getColors(image, iOSOptions[quality], (err, res) => {
     if (err) {
       callback(err);
     } else {
@@ -62,11 +75,6 @@ export const getAllSwatches = (options, image, callback) => {
         var uicolors = UIColor.split(' ');
         var colorSpace = uicolors.shift();
 
-        if (colorSpace !== 'UIDeviceRGBColorSpace') {
-          callback(`Unsupported colorspace: ${colorSpace}`);
-          return;
-        }
-
         var textColor = computeTextColor(uicolors);
 
         var r = uicolors[0];
@@ -74,8 +82,9 @@ export const getAllSwatches = (options, image, callback) => {
         var b = uicolors[2];
         var a = uicolors[3];
         var hex = '#' + toHex(r*255) + toHex(g*255) +toHex(b*255) + toHex(a*255);
+        var rgba = `rgba(${(r*255).toFixed(0)}, ${(g*255).toFixed(0)}, ${(b*255).toFixed(0)}, ${(a*255).toFixed(0)})`
         //console.log("RGB: ", UIColor, "Dominance: ",res[UIColor], "HEX:", hex);
-        swatches.push({color: hex,
+        swatches.push({color: rgba,
                        population: res[UIColor],
                        bodyTextColor: textColor,
                        titleTextColor: textColor,

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ export const getAllSwatches = (options, image, callback) => {
         var b = uicolors[2];
         var a = uicolors[3];
         var hex = '#' + toHex(r*255) + toHex(g*255) +toHex(b*255) + toHex(a*255);
-        var rgba = `rgba(${(r*255).toFixed(0)}, ${(g*255).toFixed(0)}, ${(b*255).toFixed(0)}, ${(a*255).toFixed(0)})`
+        var rgba = `rgba(${(r*255).toFixed(0)}, ${(g*255).toFixed(0)}, ${(b*255).toFixed(0)}, ${a})`
         //console.log("RGB: ", UIColor, "Dominance: ",res[UIColor], "HEX:", hex);
         swatches.push({color: rgba,
                        population: res[UIColor],

--- a/ios/RNPalette.m
+++ b/ios/RNPalette.m
@@ -1,23 +1,24 @@
 #import "RNPalette.h"
-#import "RCTLog.h"
+#import "RCTConvert.h"
 #import <AssetsLibrary/AssetsLibrary.h>
 
 @implementation RNPalette
 
 RCT_EXPORT_MODULE();
 
-RCT_EXPORT_METHOD(getColors:(NSString *)path callback:(RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(getColors:(NSString *)path options:(NSDictionary *)options callback:(RCTResponseSenderBlock)callback)
 {
 
   NSURL* aURL = [NSURL URLWithString:path];
   ALAssetsLibrary *library = [[ALAssetsLibrary alloc] init];
+  float dimension = [RCTConvert float:options[@"dimension"]]; // 4
+  float flexibility = [RCTConvert float:options[@"flexibility"]]; // 5;
+  float range = [RCTConvert float:options[@"range"]]; // 40;
+
 
   [library assetForURL:aURL resultBlock:^(ALAsset *asset) {
     UIImage  *image = [UIImage imageWithCGImage:[[asset defaultRepresentation] fullScreenImage] scale:0.5 orientation:UIImageOrientationUp];
 
-    float dimension = 4;
-    float flexibility = 5;
-    float range = 40;
 
     // determine the colours in the image
     NSMutableArray * colours = [NSMutableArray new];


### PR DESCRIPTION
Return colors in rgba(255, 255, 255, 255) format instead of Hexa.

Note that on iOS10 devices the color values may be greater than 255 or less than 0, but they will render correctly on the device.