### PR TITLE
[iOS] support uri file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,11 @@ Property | Type | Info
 -------- | ---- | ----
 `threshold` | Float | Determines whether white or black text will be selected to contrast with the selected color. It is the value for `L`, in the complex formula at the end of this [StackOverflow comment](http://stackoverflow.com/a/3943023/1404185). The default value is 0.179.
 `quality` | String | One of "low", "medium", or "high". Higher quality extracts more colors, takes more time and consumes more memory. Default is "low".
+`alpha` | Float | From 0 to 1. Determine alpha of hex property. Default is 1.
 
 #### image
 A path to an image such as that returned by [`react-native-image-picker`](https://github.com/marcshilling/react-native-image-picker). For iOS use the `origURL` field of the image picker response, because only images from `assets-library://` have been tested. For Android use the `path` field.
+Updated: For IOS, also support local URI, which is returned from `RNFS.LibraryDirectoryPath`
 
 #### callback
 The callback is passed an error parameter and an array of swatches representing the dominant colors in the image. Typically 16 swatches are returned on Android, fewer on iOS.
@@ -101,6 +103,7 @@ population | The dominance of this swatch in the image. You can sort on this fie
 titleTextColor | A text color which contrasts well with the main swatch color for use in titles.
 bodyTextColor | A text color which contrasts well with the main swatch color for use as body text.
 swatchInfo | A string encapsulating all the above and more. Can be used for debugging. Android: Note that the hex strings are in the format `#aarrggbb` rather than the `react-native` format. iOS: the result string returned by the old (`react-native-color-grabber`) API.
+hex | Hex code, computed from color, in format `#rrggbbaa` .
 
 ### Example
 ```javascript

--- a/example/components/sample.js
+++ b/example/components/sample.js
@@ -51,12 +51,12 @@ export default Sample = createReactClass( {
       this.setState({useNamed: true});
     }
   },
-  onPress() {
+  onPress(useUri) {
     console.log("Button pressed");
     if (this.state.api === 'v1') {
-      imagePicker(this.storeImage, this.state.useNamed);
+      imagePicker(this.storeImage, this.state.useNamed, useUri);
     } else {
-      imagePicker(this.storeImage, this.state.useNamed);
+      imagePicker(this.storeImage, this.state.useNamed, useUri);
     }
   },
 
@@ -67,12 +67,21 @@ export default Sample = createReactClass( {
     let textColor = this.state.colors && this.state.colors.swatches && this.state.colors.swatches[0].bodyTextColor  ? this.state.colors.swatches[0].bodyTextColor : 'white'
     let domColor = this.state.colors && this.state.colors.swatches && this.state.colors.swatches[0].color
     let buttonColor = domColor? domColor: "#841584"
-    const button = <Button
-                onPress={this.onPress}
-                title={buttonText}
-                color={buttonColor}
-                accessibilityLabel="Learn more about this purple button"
-                />;
+    const button = <View>
+      <Button
+        onPress={() => this.onPress(false)}
+        title={buttonText}
+        color={buttonColor}
+        accessibilityLabel="Learn more about this purple button"
+      />
+      <Button
+        onPress={() => this.onPress(true)}
+        title={"Load Image and Use URI"}
+        color={buttonColor}
+        accessibilityLabel="Learn more about this purple button"
+      />
+    </View>;
+    
     const imagewrapped = isImage ? <ImageBackground style={styles.image} source={{uri: 'data:image/jpeg;base64,' + this.state.colors.image, isStatic: true}}>
     {button}
     </ImageBackground> : <View>{button}<Text>{this.state.diag}</Text></View>

--- a/example/utils/ImagePicker.js
+++ b/example/utils/ImagePicker.js
@@ -21,7 +21,7 @@ function named(swatches) {
 
 
 
-export default function(storeImage, useNamed) {
+export default function(storeImage, useNamed, useUri) {
   var max = Math.max(Dimensions.get('window').width,Dimensions.get('window').height);
 
   const options = {
@@ -45,8 +45,11 @@ export default function(storeImage, useNamed) {
       console.log('ImagePickerManager Error: ', response.error);
     }
     else {
+
       colors.image = response.data;
-      var path =  Platform.OS === 'ios' ? response.origURL : response.path;
+      var path =  Platform.OS === 'ios' ? 
+                      useUri ? response.uri.split('file://')[1] : response.origURL 
+                    : response.path;
       if (useNamed) {
         getNamedSwatches(path, (error, swatches) => {
           if ( error) {

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ import { NativeModules, Platform } from 'react-native';
 const { RNPalette } = NativeModules;
 
 let Threshold = 0.179; // contrast luminosity. Original formula calls for 0.179
+let Alpha = 1;
 
 const iOSOptions = {
   low: { dimension: 5, flexibility: 5, range: 40 },
@@ -48,17 +49,25 @@ export const getNamedSwatches = (image, callback) => {
 
 // eslint-disable-next-line consistent-return
 export const getAllSwatches = (options, image, callback) => {
+  if (options.alpha) {
+    Alpha = options.alpha;
+  }
+
   if (Platform.OS === 'android') {
     return RNPalette.getAllSwatches(image, (err, res) => {
       if (err) {
         return callback(err);
       }
       res.sort((a, b) => b.population - a.population);
-      const splitColor = res[0].color.split(',');
-      const r = Number.parseFloat(splitColor[0].split('rgba(')[1]);
-      const g = Number.parseFloat(splitColor[1]);
-      const b = Number.parseFloat(splitColor[2]);
-      res[0].hex = `#${toHex(r)}${toHex(g)}${toHex(b)}${toHex(0.6)}`;
+      res.forEach(item => {
+        const splitColor = item.color.split(',');
+        const r = Number.parseFloat(splitColor[0].split('rgba(')[1]);
+        const g = Number.parseFloat(splitColor[1]);
+        const b = Number.parseFloat(splitColor[2]);
+        const a = Number.parseFloat(splitColor[3].split(')')[0]);
+        item.hex = `#${toHex(r)}${toHex(g)}${toHex(b)}${toHex(a*255*Alpha)}`;
+      })
+
       return callback(err, res);
     });
   }
@@ -92,7 +101,7 @@ export const getAllSwatches = (options, image, callback) => {
         const g = uicolors[1];
         const b = uicolors[2];
         const a = uicolors[3];
-        const hex = `#${toHex(r * 255)}${toHex(g * 255)}${toHex(b * 255)}${toHex(0.6)}`;
+        const hex = `#${toHex(r * 255)}${toHex(g * 255)}${toHex(b * 255)}${toHex(a*255*Alpha)}`;
         const rgba = `rgba(${(r * 255).toFixed(0)}, ${(g * 255).toFixed(0)}, ${(b * 255).toFixed(0)}, ${a})`;
         // console.log("RGB: ", UIColor, "Dominance: ",res[UIColor], "HEX:", hex);
         swatches.push({ color: rgba,

--- a/index.js
+++ b/index.js
@@ -1,20 +1,20 @@
-'use strict'
 
 import { NativeModules, Platform } from 'react-native';
+
 const { RNPalette } = NativeModules;
 
-var Threshold = 0.179; // contrast luminosity. Original formula calls for 0.179
+let Threshold = 0.179; // contrast luminosity. Original formula calls for 0.179
 
-var iOSOptions = {
-low: { dimension: 5, flexibility: 5, range: 40 },
-medium: { dimension: 8, flexibility: 5, range: 40 },
-high: { dimension: 10, flexibility: 10, range: 30 }
+const iOSOptions = {
+  low: { dimension: 5, flexibility: 5, range: 40 },
+  medium: { dimension: 8, flexibility: 5, range: 40 },
+  high: { dimension: 10, flexibility: 10, range: 30 },
 };
 
-let quality = "low"
+let quality = 'low';
 
 function toHex(d) {
-  return  ("0"+(Math.round(d).toString(16))).slice(-2).toUpperCase()
+  return (`0${Math.round(d).toString(16)}`).slice(-2).toUpperCase();
 }
 
 function computeTextColor(uicolors) {
@@ -24,74 +24,86 @@ function computeTextColor(uicolors) {
    *  if c <= 0.03928 then c = c/12.92 else c = ((c+0.055)/1.055) ^ 2.4
    *  L = 0.2126 * r + 0.7152 * g + 0.0722 * b
    */
-  var c = uicolors.map((c)=> {
-    c = Number(c);
-    if (c <= 0.03928 ) {
-      return c/12.92;
-    } else {
-      return Math.pow((c+0.055)/1.055, 2.4);
+  const c = uicolors.map((color) => {
+    const colorNum = Number(color);
+    if (colorNum <= 0.03928) {
+      return colorNum / 12.92;
     }
+    return ((colorNum + 0.055) / 1.055) ** 2.4;
   });
 
-  var L = 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2];
+  const L = 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2];
 
   return (L > Threshold) ? '#000000ff' : '#ffffffff';
   // well if that doesnt' work, simplify!
-  //colors.textColor = ((r*255*0.299 + g*255*0.587 + b*255*0.114) > 186) ? '#000000' : '#ffffff';
+  // colors.textColor = ((r*255*0.299 + g*255*0.587 + b*255*0.114) > 186) ? '#000000' : '#ffffff';
 }
+// eslint-disable-next-line consistent-return
 export const getNamedSwatches = (image, callback) => {
   if (Platform.OS === 'android') {
     return RNPalette.getNamedSwatches(image, callback);
-  } else {
-    callback("Not supported");
   }
-}
+  callback('Not supported');
+};
 
-
+// eslint-disable-next-line consistent-return
 export const getAllSwatches = (options, image, callback) => {
   if (Platform.OS === 'android') {
-    return RNPalette.getAllSwatches(image, callback);
+    return RNPalette.getAllSwatches(image, (err, res) => {
+      if (err) {
+        return callback(err);
+      }
+      res.sort((a, b) => b.population - a.population);
+      const splitColor = res[0].color.split(',');
+      const r = Number.parseFloat(splitColor[0].split('rgba(')[1]);
+      const g = Number.parseFloat(splitColor[1]);
+      const b = Number.parseFloat(splitColor[2]);
+      res[0].hex = `#${toHex(r)}${toHex(g)}${toHex(b)}${toHex(0.6)}`;
+      return callback(err, res);
+    });
   }
-  if (options.hasOwnProperty('threshold')) {
+
+  if (options.threshold) {
     Threshold = options.threshold;
   }
 
-  if (options.hasOwnProperty('quality')) {
-    quality = options.quality
+  if (options.quality) {
+    quality = options.quality;
   }
 
   RNPalette.getColors(image, iOSOptions[quality], (err, res) => {
     if (err) {
       callback(err);
     } else {
-      var props = Object.keys(res);
+      const props = Object.keys(res);
       // convert all dominant to hex
-      var maxResults = 16;
-      var domColors = [];
-      var swatches = [];
+      const maxResults = 16;
+      // const domColors = [];
+      const swatches = [];
       /*           colors.complementColors = []; */
-      for (var i = 0 ; i< props.length && i < maxResults ; i++) {
-        var UIColor = props[i];
-        var uicolors = UIColor.split(' ');
-        var colorSpace = uicolors.shift();
+      for (let i = 0; i < props.length && i < maxResults; i++) {
+        const UIColor = props[i];
+        const uicolors = UIColor.split(' ');
+        uicolors.shift();
 
-        var textColor = computeTextColor(uicolors);
+        const textColor = computeTextColor(uicolors);
 
-        var r = uicolors[0];
-        var g = uicolors[1];
-        var b = uicolors[2];
-        var a = uicolors[3];
-        var hex = '#' + toHex(r*255) + toHex(g*255) +toHex(b*255) + toHex(a*255);
-        var rgba = `rgba(${(r*255).toFixed(0)}, ${(g*255).toFixed(0)}, ${(b*255).toFixed(0)}, ${a})`
-        //console.log("RGB: ", UIColor, "Dominance: ",res[UIColor], "HEX:", hex);
-        swatches.push({color: rgba,
-                       population: res[UIColor],
-                       bodyTextColor: textColor,
-                       titleTextColor: textColor,
-                       swatchInfo: UIColor,
+        const r = uicolors[0];
+        const g = uicolors[1];
+        const b = uicolors[2];
+        const a = uicolors[3];
+        const hex = `#${toHex(r * 255)}${toHex(g * 255)}${toHex(b * 255)}${toHex(0.6)}`;
+        const rgba = `rgba(${(r * 255).toFixed(0)}, ${(g * 255).toFixed(0)}, ${(b * 255).toFixed(0)}, ${a})`;
+        // console.log("RGB: ", UIColor, "Dominance: ",res[UIColor], "HEX:", hex);
+        swatches.push({ color: rgba,
+          population: res[UIColor],
+          bodyTextColor: textColor,
+          titleTextColor: textColor,
+          swatchInfo: UIColor,
+          hex,
         });
       }
       callback(false, swatches);
     }
-  })
-}
+  });
+};

--- a/ios/RNPalette.h
+++ b/ios/RNPalette.h
@@ -3,5 +3,7 @@
 #import "RCTBridgeModule.h"
 
 @interface RNPalette : NSObject <RCTBridgeModule>
-
+- (void)extractColor: (UIImage*) image
+    options:(NSDictionary *)options
+    callback : (RCTResponseSenderBlock) callback;
 @end

--- a/ios/RNPalette.m
+++ b/ios/RNPalette.m
@@ -6,182 +6,201 @@
 
 RCT_EXPORT_MODULE();
 
+- (void) extractColor: (UIImage*) image
+              options:(NSDictionary *)options
+            callback : (RCTResponseSenderBlock) callback {
+    
+    float dimension = [RCTConvert float:options[@"dimension"]]; // 4
+    float flexibility = [RCTConvert float:options[@"flexibility"]]; // 5;
+    float range = [RCTConvert float:options[@"range"]]; // 40;
+    
+    // determine the colours in the image
+    NSMutableArray * colours = [NSMutableArray new];
+    CGImageRef imageRef = [image CGImage];
+    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+    unsigned char *rawData = (unsigned char*) calloc(dimension * dimension * 4, sizeof(unsigned char));
+    NSUInteger bytesPerPixel = 4;
+    NSUInteger bytesPerRow = bytesPerPixel * dimension;
+    NSUInteger bitsPerComponent = 8;
+    CGContextRef context = CGBitmapContextCreate(rawData, dimension, dimension, bitsPerComponent, bytesPerRow, colorSpace, kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big);
+    CGColorSpaceRelease(colorSpace);
+    CGContextDrawImage(context, CGRectMake(0, 0, dimension, dimension), imageRef);
+    CGContextRelease(context);
+    
+    float x = 0;
+    float y = 0;
+    for (int n = 0; n<(dimension*dimension); n++){
+        
+        int index = (bytesPerRow * y) + x * bytesPerPixel;
+        int red   = rawData[index];
+        int green = rawData[index + 1];
+        int blue  = rawData[index + 2];
+        int alpha = rawData[index + 3];
+        NSArray * a = [NSArray arrayWithObjects:[NSString stringWithFormat:@"%i",red],[NSString stringWithFormat:@"%i",green],[NSString stringWithFormat:@"%i",blue],[NSString stringWithFormat:@"%i",alpha], nil];
+        [colours addObject:a];
+        
+        y++;
+        if (y==dimension){
+            y=0;
+            x++;
+        }
+    }
+    free(rawData);
+    
+    // Add some colour flexibility (adds more colours either side of the colours in the image)
+    NSArray * copyColours = [NSArray arrayWithArray:colours];
+    NSMutableArray * flexibleColours = [NSMutableArray new];
+    
+    float flexFactor = flexibility * 2 + 1;
+    float factor = flexFactor * flexFactor * 3; //(r,g,b) == *3
+    for (int n = 0; n<(dimension * dimension); n++){
+        
+        NSArray * pixelColours = copyColours[n];
+        NSMutableArray * reds = [NSMutableArray new];
+        NSMutableArray * greens = [NSMutableArray new];
+        NSMutableArray * blues = [NSMutableArray new];
+        
+        for (int p = 0; p<3; p++){
+            
+            NSString * rgbStr = pixelColours[p];
+            int rgb = [rgbStr intValue];
+            
+            for (int f = -flexibility; f<flexibility+1; f++){
+                int newRGB = rgb+f;
+                if (newRGB<0){
+                    newRGB = 0;
+                }
+                if (p==0){
+                    [reds addObject:[NSString stringWithFormat:@"%i",newRGB]];
+                } else if (p==1){
+                    [greens addObject:[NSString stringWithFormat:@"%i",newRGB]];
+                } else if (p==2){
+                    [blues addObject:[NSString stringWithFormat:@"%i",newRGB]];
+                }
+            }
+        }
+        
+        int r = 0;
+        int g = 0;
+        int b = 0;
+        for (int k = 0; k<factor; k++){
+            
+            int red = [reds[r] intValue];
+            int green = [greens[g] intValue];
+            int blue = [blues[b] intValue];
+            
+            NSString * rgbString = [NSString stringWithFormat:@"%i,%i,%i",red,green,blue];
+            [flexibleColours addObject:rgbString];
+            
+            b++;
+            if (b==flexFactor){ b=0; g++; }
+            if (g==flexFactor){ g=0; r++; }
+        }
+    }
+    
+    // Distinguish the colours
+    // orders the flexible colours by their occurrence
+    // then keeps them if they are sufficiently disimilar
+    
+    NSMutableDictionary * colourCounter = [NSMutableDictionary new];
+    
+    //count the occurences in the array
+    NSCountedSet *countedSet = [[NSCountedSet alloc] initWithArray:flexibleColours];
+    for (NSString *item in countedSet) {
+        NSUInteger count = [countedSet countForObject:item];
+        [colourCounter setValue:[NSNumber numberWithInteger:count] forKey:item];
+    }
+    
+    // Sort keys highest occurrence to lowest
+    NSArray *orderedKeys = [colourCounter keysSortedByValueUsingComparator:^NSComparisonResult(id obj1, id obj2){
+        return [obj2 compare:obj1];
+    }];
+    
+    // Checks if the colour is similar to another one already included
+    NSMutableArray * ranges = [NSMutableArray new];
+    for (NSString * key in orderedKeys){
+        NSArray * rgb = [key componentsSeparatedByString:@","];
+        int r = [rgb[0] intValue];
+        int g = [rgb[1] intValue];
+        int b = [rgb[2] intValue];
+        bool exclude = false;
+        for (NSString * ranged_key in ranges){
+            NSArray * ranged_rgb = [ranged_key componentsSeparatedByString:@","];
+            
+            int ranged_r = [ranged_rgb[0] intValue];
+            int ranged_g = [ranged_rgb[1] intValue];
+            int ranged_b = [ranged_rgb[2] intValue];
+            
+            if (r>= ranged_r-range && r<= ranged_r+range){
+                if (g>= ranged_g-range && g<= ranged_g+range){
+                    if (b>= ranged_b-range && b<= ranged_b+range){
+                        exclude = true;
+                    }
+                }
+            }
+        }
+        
+        if (!exclude){ [ranges addObject:key]; }
+    }
+    
+    // Return ranges array here if you just want the ordered colours high to low
+    NSMutableArray * colourArray = [NSMutableArray new];
+    for (NSString * key in ranges){
+        NSArray * rgb = [key componentsSeparatedByString:@","];
+        float r = [rgb[0] floatValue];
+        float g = [rgb[1] floatValue];
+        float b = [rgb[2] floatValue];
+        UIColor * colour = [UIColor colorWithRed:(r/255.0f) green:(g/255.0f) blue:(b/255.0f) alpha:1.0f];
+        [colourArray addObject:colour];
+    }
+    
+    // If you want percentages to colours continue below
+    NSMutableDictionary * temp = [NSMutableDictionary new];
+    float totalCount = 0.0f;
+    for (NSString * rangeKey in ranges){
+        NSNumber * count = colourCounter[rangeKey];
+        totalCount += [count intValue];
+        temp[rangeKey]=count;
+    }
+    
+    // Set percentages
+    NSMutableDictionary * colourDictionary = [NSMutableDictionary new];
+    for (NSString * key in temp){
+        float count = [temp[key] floatValue];
+        float percentage = count/totalCount;
+        NSLog(@"%f",percentage);
+        NSArray * rgb = [key componentsSeparatedByString:@","];
+        float r = [rgb[0] floatValue];
+        float g = [rgb[1] floatValue];
+        float b = [rgb[2] floatValue];
+        NSString* colour = [[UIColor colorWithRed:(r/255.0f) green:(g/255.0f) blue:(b/255.0f) alpha:1.0f] description];
+        colourDictionary[colour]=[[NSNumber numberWithFloat:percentage] description];
+    }
+    
+    callback(@[[NSNull null], colourDictionary]);
+}
+
 RCT_EXPORT_METHOD(getColors:(NSString *)path options:(NSDictionary *)options callback:(RCTResponseSenderBlock)callback)
 {
-      float dimension = [RCTConvert float:options[@"dimension"]]; // 4
-      float flexibility = [RCTConvert float:options[@"flexibility"]]; // 5;
-      float range = [RCTConvert float:options[@"range"]]; // 40;
     NSFileManager *fileManager = [NSFileManager defaultManager];
     BOOL isFileExist = [fileManager fileExistsAtPath: path];
     UIImage *image;
     if (isFileExist) {
         image = [[UIImage alloc] initWithContentsOfFile:path];
-
-        NSMutableArray * colours = [NSMutableArray new];
-        CGImageRef imageRef = [image CGImage];
-        CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-        unsigned char *rawData = (unsigned char*) calloc(dimension * dimension * 4, sizeof(unsigned char));
-        NSUInteger bytesPerPixel = 4;
-        NSUInteger bytesPerRow = bytesPerPixel * dimension;
-        NSUInteger bitsPerComponent = 8;
-        CGContextRef context = CGBitmapContextCreate(rawData, dimension, dimension, bitsPerComponent, bytesPerRow, colorSpace, kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big);
-        CGColorSpaceRelease(colorSpace);
-        CGContextDrawImage(context, CGRectMake(0, 0, dimension, dimension), imageRef);
-        CGContextRelease(context);
-
-        float x = 0;
-        float y = 0;
-        for (int n = 0; n<(dimension*dimension); n++){
-
-          int index = (bytesPerRow * y) + x * bytesPerPixel;
-          int red   = rawData[index];
-          int green = rawData[index + 1];
-          int blue  = rawData[index + 2];
-          int alpha = rawData[index + 3];
-          NSArray * a = [NSArray arrayWithObjects:[NSString stringWithFormat:@"%i",red],[NSString stringWithFormat:@"%i",green],[NSString stringWithFormat:@"%i",blue],[NSString stringWithFormat:@"%i",alpha], nil];
-          [colours addObject:a];
-
-          y++;
-          if (y==dimension){
-            y=0;
-            x++;
-          }
+        [self extractColor:image options:options callback:callback];
+    }
+    else {
+        NSURL* aURL = [NSURL URLWithString:path];
+        ALAssetsLibrary *library = [[ALAssetsLibrary alloc] init];
+        
+        [library assetForURL:aURL resultBlock:^(ALAsset *asset) {
+            UIImage  *image = [UIImage imageWithCGImage:[[asset defaultRepresentation] fullScreenImage] scale:0.5 orientation:UIImageOrientationUp];
+            
+            [self extractColor:image options:options callback:callback];
         }
-        free(rawData);
-
-        // Add some colour flexibility (adds more colours either side of the colours in the image)
-        NSArray * copyColours = [NSArray arrayWithArray:colours];
-        NSMutableArray * flexibleColours = [NSMutableArray new];
-
-        float flexFactor = flexibility * 2 + 1;
-        float factor = flexFactor * flexFactor * 3; //(r,g,b) == *3
-        for (int n = 0; n<(dimension * dimension); n++){
-
-          NSArray * pixelColours = copyColours[n];
-          NSMutableArray * reds = [NSMutableArray new];
-          NSMutableArray * greens = [NSMutableArray new];
-          NSMutableArray * blues = [NSMutableArray new];
-
-          for (int p = 0; p<3; p++){
-
-            NSString * rgbStr = pixelColours[p];
-            int rgb = [rgbStr intValue];
-
-            for (int f = -flexibility; f<flexibility+1; f++){
-              int newRGB = rgb+f;
-              if (newRGB<0){
-                newRGB = 0;
-              }
-              if (p==0){
-                [reds addObject:[NSString stringWithFormat:@"%i",newRGB]];
-              } else if (p==1){
-                [greens addObject:[NSString stringWithFormat:@"%i",newRGB]];
-              } else if (p==2){
-                [blues addObject:[NSString stringWithFormat:@"%i",newRGB]];
-              }
-            }
-          }
-
-          int r = 0;
-          int g = 0;
-          int b = 0;
-          for (int k = 0; k<factor; k++){
-
-            int red = [reds[r] intValue];
-            int green = [greens[g] intValue];
-            int blue = [blues[b] intValue];
-
-            NSString * rgbString = [NSString stringWithFormat:@"%i,%i,%i",red,green,blue];
-            [flexibleColours addObject:rgbString];
-
-            b++;
-            if (b==flexFactor){ b=0; g++; }
-            if (g==flexFactor){ g=0; r++; }
-          }
-        }
-
-        // Distinguish the colours
-        // orders the flexible colours by their occurrence
-        // then keeps them if they are sufficiently disimilar
-
-        NSMutableDictionary * colourCounter = [NSMutableDictionary new];
-
-        //count the occurences in the array
-        NSCountedSet *countedSet = [[NSCountedSet alloc] initWithArray:flexibleColours];
-        for (NSString *item in countedSet) {
-          NSUInteger count = [countedSet countForObject:item];
-          [colourCounter setValue:[NSNumber numberWithInteger:count] forKey:item];
-        }
-
-        // Sort keys highest occurrence to lowest
-        NSArray *orderedKeys = [colourCounter keysSortedByValueUsingComparator:^NSComparisonResult(id obj1, id obj2){
-          return [obj2 compare:obj1];
+                failureBlock:^(NSError *error) {
+            NSLog(@"failure-----");
         }];
-
-        // Checks if the colour is similar to another one already included
-        NSMutableArray * ranges = [NSMutableArray new];
-        for (NSString * key in orderedKeys){
-          NSArray * rgb = [key componentsSeparatedByString:@","];
-          int r = [rgb[0] intValue];
-          int g = [rgb[1] intValue];
-          int b = [rgb[2] intValue];
-          bool exclude = false;
-          for (NSString * ranged_key in ranges){
-            NSArray * ranged_rgb = [ranged_key componentsSeparatedByString:@","];
-
-            int ranged_r = [ranged_rgb[0] intValue];
-            int ranged_g = [ranged_rgb[1] intValue];
-            int ranged_b = [ranged_rgb[2] intValue];
-
-            if (r>= ranged_r-range && r<= ranged_r+range){
-              if (g>= ranged_g-range && g<= ranged_g+range){
-                if (b>= ranged_b-range && b<= ranged_b+range){
-                  exclude = true;
-                }
-              }
-            }
-          }
-
-          if (!exclude){ [ranges addObject:key]; }
-        }
-
-        // Return ranges array here if you just want the ordered colours high to low
-        NSMutableArray * colourArray = [NSMutableArray new];
-        for (NSString * key in ranges){
-          NSArray * rgb = [key componentsSeparatedByString:@","];
-          float r = [rgb[0] floatValue];
-          float g = [rgb[1] floatValue];
-          float b = [rgb[2] floatValue];
-          UIColor * colour = [UIColor colorWithRed:(r/255.0f) green:(g/255.0f) blue:(b/255.0f) alpha:1.0f];
-          [colourArray addObject:colour];
-        }
-
-        // If you want percentages to colours continue below
-        NSMutableDictionary * temp = [NSMutableDictionary new];
-        float totalCount = 0.0f;
-        for (NSString * rangeKey in ranges){
-          NSNumber * count = colourCounter[rangeKey];
-          totalCount += [count intValue];
-          temp[rangeKey]=count;
-        }
-
-        // Set percentages
-        NSMutableDictionary * colourDictionary = [NSMutableDictionary new];
-        for (NSString * key in temp){
-          float count = [temp[key] floatValue];
-          float percentage = count/totalCount;
-          NSLog(@"%f",percentage);
-          NSArray * rgb = [key componentsSeparatedByString:@","];
-          float r = [rgb[0] floatValue];
-          float g = [rgb[1] floatValue];
-          float b = [rgb[2] floatValue];
-          NSString* colour = [[UIColor colorWithRed:(r/255.0f) green:(g/255.0f) blue:(b/255.0f) alpha:1.0f] description];
-          colourDictionary[colour]=[[NSNumber numberWithFloat:percentage] description];
-        }
-
-        callback(@[[NSNull null], colourDictionary]);
-    }else {
-        NSLog(@"failure-----");
     }
 }
 

--- a/ios/RNPalette.m
+++ b/ios/RNPalette.m
@@ -8,188 +8,181 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(getColors:(NSString *)path options:(NSDictionary *)options callback:(RCTResponseSenderBlock)callback)
 {
+      float dimension = [RCTConvert float:options[@"dimension"]]; // 4
+      float flexibility = [RCTConvert float:options[@"flexibility"]]; // 5;
+      float range = [RCTConvert float:options[@"range"]]; // 40;
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    BOOL isFileExist = [fileManager fileExistsAtPath: path];
+    UIImage *image;
+    if (isFileExist) {
+        image = [[UIImage alloc] initWithContentsOfFile:path];
 
-  NSURL* aURL = [NSURL URLWithString:path];
-  ALAssetsLibrary *library = [[ALAssetsLibrary alloc] init];
-  float dimension = [RCTConvert float:options[@"dimension"]]; // 4
-  float flexibility = [RCTConvert float:options[@"flexibility"]]; // 5;
-  float range = [RCTConvert float:options[@"range"]]; // 40;
+        NSMutableArray * colours = [NSMutableArray new];
+        CGImageRef imageRef = [image CGImage];
+        CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+        unsigned char *rawData = (unsigned char*) calloc(dimension * dimension * 4, sizeof(unsigned char));
+        NSUInteger bytesPerPixel = 4;
+        NSUInteger bytesPerRow = bytesPerPixel * dimension;
+        NSUInteger bitsPerComponent = 8;
+        CGContextRef context = CGBitmapContextCreate(rawData, dimension, dimension, bitsPerComponent, bytesPerRow, colorSpace, kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big);
+        CGColorSpaceRelease(colorSpace);
+        CGContextDrawImage(context, CGRectMake(0, 0, dimension, dimension), imageRef);
+        CGContextRelease(context);
 
+        float x = 0;
+        float y = 0;
+        for (int n = 0; n<(dimension*dimension); n++){
 
-  [library assetForURL:aURL resultBlock:^(ALAsset *asset) {
-    UIImage  *image = [UIImage imageWithCGImage:[[asset defaultRepresentation] fullScreenImage] scale:0.5 orientation:UIImageOrientationUp];
+          int index = (bytesPerRow * y) + x * bytesPerPixel;
+          int red   = rawData[index];
+          int green = rawData[index + 1];
+          int blue  = rawData[index + 2];
+          int alpha = rawData[index + 3];
+          NSArray * a = [NSArray arrayWithObjects:[NSString stringWithFormat:@"%i",red],[NSString stringWithFormat:@"%i",green],[NSString stringWithFormat:@"%i",blue],[NSString stringWithFormat:@"%i",alpha], nil];
+          [colours addObject:a];
 
-
-    // determine the colours in the image
-    NSMutableArray * colours = [NSMutableArray new];
-    CGImageRef imageRef = [image CGImage];
-    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-    unsigned char *rawData = (unsigned char*) calloc(dimension * dimension * 4, sizeof(unsigned char));
-    NSUInteger bytesPerPixel = 4;
-    NSUInteger bytesPerRow = bytesPerPixel * dimension;
-    NSUInteger bitsPerComponent = 8;
-    CGContextRef context = CGBitmapContextCreate(rawData, dimension, dimension, bitsPerComponent, bytesPerRow, colorSpace, kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big);
-    CGColorSpaceRelease(colorSpace);
-    CGContextDrawImage(context, CGRectMake(0, 0, dimension, dimension), imageRef);
-    CGContextRelease(context);
-
-    float x = 0;
-    float y = 0;
-    for (int n = 0; n<(dimension*dimension); n++){
-
-      int index = (bytesPerRow * y) + x * bytesPerPixel;
-      int red   = rawData[index];
-      int green = rawData[index + 1];
-      int blue  = rawData[index + 2];
-      int alpha = rawData[index + 3];
-      NSArray * a = [NSArray arrayWithObjects:[NSString stringWithFormat:@"%i",red],[NSString stringWithFormat:@"%i",green],[NSString stringWithFormat:@"%i",blue],[NSString stringWithFormat:@"%i",alpha], nil];
-      [colours addObject:a];
-
-      y++;
-      if (y==dimension){
-        y=0;
-        x++;
-      }
-    }
-    free(rawData);
-
-    // Add some colour flexibility (adds more colours either side of the colours in the image)
-    NSArray * copyColours = [NSArray arrayWithArray:colours];
-    NSMutableArray * flexibleColours = [NSMutableArray new];
-
-    float flexFactor = flexibility * 2 + 1;
-    float factor = flexFactor * flexFactor * 3; //(r,g,b) == *3
-    for (int n = 0; n<(dimension * dimension); n++){
-
-      NSArray * pixelColours = copyColours[n];
-      NSMutableArray * reds = [NSMutableArray new];
-      NSMutableArray * greens = [NSMutableArray new];
-      NSMutableArray * blues = [NSMutableArray new];
-
-      for (int p = 0; p<3; p++){
-
-        NSString * rgbStr = pixelColours[p];
-        int rgb = [rgbStr intValue];
-
-        for (int f = -flexibility; f<flexibility+1; f++){
-          int newRGB = rgb+f;
-          if (newRGB<0){
-            newRGB = 0;
-          }
-          if (p==0){
-            [reds addObject:[NSString stringWithFormat:@"%i",newRGB]];
-          } else if (p==1){
-            [greens addObject:[NSString stringWithFormat:@"%i",newRGB]];
-          } else if (p==2){
-            [blues addObject:[NSString stringWithFormat:@"%i",newRGB]];
+          y++;
+          if (y==dimension){
+            y=0;
+            x++;
           }
         }
-      }
+        free(rawData);
 
-      int r = 0;
-      int g = 0;
-      int b = 0;
-      for (int k = 0; k<factor; k++){
+        // Add some colour flexibility (adds more colours either side of the colours in the image)
+        NSArray * copyColours = [NSArray arrayWithArray:colours];
+        NSMutableArray * flexibleColours = [NSMutableArray new];
 
-        int red = [reds[r] intValue];
-        int green = [greens[g] intValue];
-        int blue = [blues[b] intValue];
+        float flexFactor = flexibility * 2 + 1;
+        float factor = flexFactor * flexFactor * 3; //(r,g,b) == *3
+        for (int n = 0; n<(dimension * dimension); n++){
 
-        NSString * rgbString = [NSString stringWithFormat:@"%i,%i,%i",red,green,blue];
-        [flexibleColours addObject:rgbString];
+          NSArray * pixelColours = copyColours[n];
+          NSMutableArray * reds = [NSMutableArray new];
+          NSMutableArray * greens = [NSMutableArray new];
+          NSMutableArray * blues = [NSMutableArray new];
 
-        b++;
-        if (b==flexFactor){ b=0; g++; }
-        if (g==flexFactor){ g=0; r++; }
-      }
-    }
+          for (int p = 0; p<3; p++){
 
-    // Distinguish the colours
-    // orders the flexible colours by their occurrence
-    // then keeps them if they are sufficiently disimilar
+            NSString * rgbStr = pixelColours[p];
+            int rgb = [rgbStr intValue];
 
-    NSMutableDictionary * colourCounter = [NSMutableDictionary new];
-
-    //count the occurences in the array
-    NSCountedSet *countedSet = [[NSCountedSet alloc] initWithArray:flexibleColours];
-    for (NSString *item in countedSet) {
-      NSUInteger count = [countedSet countForObject:item];
-      [colourCounter setValue:[NSNumber numberWithInteger:count] forKey:item];
-    }
-
-    // Sort keys highest occurrence to lowest
-    NSArray *orderedKeys = [colourCounter keysSortedByValueUsingComparator:^NSComparisonResult(id obj1, id obj2){
-      return [obj2 compare:obj1];
-    }];
-
-    // Checks if the colour is similar to another one already included
-    NSMutableArray * ranges = [NSMutableArray new];
-    for (NSString * key in orderedKeys){
-      NSArray * rgb = [key componentsSeparatedByString:@","];
-      int r = [rgb[0] intValue];
-      int g = [rgb[1] intValue];
-      int b = [rgb[2] intValue];
-      bool exclude = false;
-      for (NSString * ranged_key in ranges){
-        NSArray * ranged_rgb = [ranged_key componentsSeparatedByString:@","];
-
-        int ranged_r = [ranged_rgb[0] intValue];
-        int ranged_g = [ranged_rgb[1] intValue];
-        int ranged_b = [ranged_rgb[2] intValue];
-
-        if (r>= ranged_r-range && r<= ranged_r+range){
-          if (g>= ranged_g-range && g<= ranged_g+range){
-            if (b>= ranged_b-range && b<= ranged_b+range){
-              exclude = true;
+            for (int f = -flexibility; f<flexibility+1; f++){
+              int newRGB = rgb+f;
+              if (newRGB<0){
+                newRGB = 0;
+              }
+              if (p==0){
+                [reds addObject:[NSString stringWithFormat:@"%i",newRGB]];
+              } else if (p==1){
+                [greens addObject:[NSString stringWithFormat:@"%i",newRGB]];
+              } else if (p==2){
+                [blues addObject:[NSString stringWithFormat:@"%i",newRGB]];
+              }
             }
           }
+
+          int r = 0;
+          int g = 0;
+          int b = 0;
+          for (int k = 0; k<factor; k++){
+
+            int red = [reds[r] intValue];
+            int green = [greens[g] intValue];
+            int blue = [blues[b] intValue];
+
+            NSString * rgbString = [NSString stringWithFormat:@"%i,%i,%i",red,green,blue];
+            [flexibleColours addObject:rgbString];
+
+            b++;
+            if (b==flexFactor){ b=0; g++; }
+            if (g==flexFactor){ g=0; r++; }
+          }
         }
-      }
 
-      if (!exclude){ [ranges addObject:key]; }
+        // Distinguish the colours
+        // orders the flexible colours by their occurrence
+        // then keeps them if they are sufficiently disimilar
+
+        NSMutableDictionary * colourCounter = [NSMutableDictionary new];
+
+        //count the occurences in the array
+        NSCountedSet *countedSet = [[NSCountedSet alloc] initWithArray:flexibleColours];
+        for (NSString *item in countedSet) {
+          NSUInteger count = [countedSet countForObject:item];
+          [colourCounter setValue:[NSNumber numberWithInteger:count] forKey:item];
+        }
+
+        // Sort keys highest occurrence to lowest
+        NSArray *orderedKeys = [colourCounter keysSortedByValueUsingComparator:^NSComparisonResult(id obj1, id obj2){
+          return [obj2 compare:obj1];
+        }];
+
+        // Checks if the colour is similar to another one already included
+        NSMutableArray * ranges = [NSMutableArray new];
+        for (NSString * key in orderedKeys){
+          NSArray * rgb = [key componentsSeparatedByString:@","];
+          int r = [rgb[0] intValue];
+          int g = [rgb[1] intValue];
+          int b = [rgb[2] intValue];
+          bool exclude = false;
+          for (NSString * ranged_key in ranges){
+            NSArray * ranged_rgb = [ranged_key componentsSeparatedByString:@","];
+
+            int ranged_r = [ranged_rgb[0] intValue];
+            int ranged_g = [ranged_rgb[1] intValue];
+            int ranged_b = [ranged_rgb[2] intValue];
+
+            if (r>= ranged_r-range && r<= ranged_r+range){
+              if (g>= ranged_g-range && g<= ranged_g+range){
+                if (b>= ranged_b-range && b<= ranged_b+range){
+                  exclude = true;
+                }
+              }
+            }
+          }
+
+          if (!exclude){ [ranges addObject:key]; }
+        }
+
+        // Return ranges array here if you just want the ordered colours high to low
+        NSMutableArray * colourArray = [NSMutableArray new];
+        for (NSString * key in ranges){
+          NSArray * rgb = [key componentsSeparatedByString:@","];
+          float r = [rgb[0] floatValue];
+          float g = [rgb[1] floatValue];
+          float b = [rgb[2] floatValue];
+          UIColor * colour = [UIColor colorWithRed:(r/255.0f) green:(g/255.0f) blue:(b/255.0f) alpha:1.0f];
+          [colourArray addObject:colour];
+        }
+
+        // If you want percentages to colours continue below
+        NSMutableDictionary * temp = [NSMutableDictionary new];
+        float totalCount = 0.0f;
+        for (NSString * rangeKey in ranges){
+          NSNumber * count = colourCounter[rangeKey];
+          totalCount += [count intValue];
+          temp[rangeKey]=count;
+        }
+
+        // Set percentages
+        NSMutableDictionary * colourDictionary = [NSMutableDictionary new];
+        for (NSString * key in temp){
+          float count = [temp[key] floatValue];
+          float percentage = count/totalCount;
+          NSLog(@"%f",percentage);
+          NSArray * rgb = [key componentsSeparatedByString:@","];
+          float r = [rgb[0] floatValue];
+          float g = [rgb[1] floatValue];
+          float b = [rgb[2] floatValue];
+          NSString* colour = [[UIColor colorWithRed:(r/255.0f) green:(g/255.0f) blue:(b/255.0f) alpha:1.0f] description];
+          colourDictionary[colour]=[[NSNumber numberWithFloat:percentage] description];
+        }
+
+        callback(@[[NSNull null], colourDictionary]);
+    }else {
+        NSLog(@"failure-----");
     }
-
-    // Return ranges array here if you just want the ordered colours high to low
-    NSMutableArray * colourArray = [NSMutableArray new];
-    for (NSString * key in ranges){
-      NSArray * rgb = [key componentsSeparatedByString:@","];
-      float r = [rgb[0] floatValue];
-      float g = [rgb[1] floatValue];
-      float b = [rgb[2] floatValue];
-      UIColor * colour = [UIColor colorWithRed:(r/255.0f) green:(g/255.0f) blue:(b/255.0f) alpha:1.0f];
-      [colourArray addObject:colour];
-    }
-
-    // If you want percentages to colours continue below
-    NSMutableDictionary * temp = [NSMutableDictionary new];
-    float totalCount = 0.0f;
-    for (NSString * rangeKey in ranges){
-      NSNumber * count = colourCounter[rangeKey];
-      totalCount += [count intValue];
-      temp[rangeKey]=count;
-    }
-
-    // Set percentages
-    NSMutableDictionary * colourDictionary = [NSMutableDictionary new];
-    for (NSString * key in temp){
-      float count = [temp[key] floatValue];
-      float percentage = count/totalCount;
-      NSLog(@"%f",percentage);
-      NSArray * rgb = [key componentsSeparatedByString:@","];
-      float r = [rgb[0] floatValue];
-      float g = [rgb[1] floatValue];
-      float b = [rgb[2] floatValue];
-      NSString* colour = [[UIColor colorWithRed:(r/255.0f) green:(g/255.0f) blue:(b/255.0f) alpha:1.0f] description];
-      colourDictionary[colour]=[[NSNumber numberWithFloat:percentage] description];
-    }
-
-    callback(@[[NSNull null], colourDictionary]);
-  }
-          failureBlock:^(NSError *error) {
-            NSLog(@"failure-----");
-          }];
-
-
 }
 
 @end


### PR DESCRIPTION
added button in example for testing the feature

### Issue:
in IOS, it currently only support assets with path
`assets-library://asset/asset.JPG?id=B84E8479-475C-4727-A4A4-B77AA9980897&ext=JPG
`

However, in some case the file path is not under asset-library, 
if we supply it with uri file path such as
`/Users/cuongchau93/Library/Developer/CoreSimulator/Devices/C1105148-CD13-4EB7-98DB-B2A631B5B46E/data/Containers/Data/Application/A298452C-613C-46B0-BC9B-11FDD1475C1B/tmp/DEFA99E7-CA1F-4A77-A16B-4321CDCE3DA8.jpg
`
it does not work (in my app, it crashed. In the example app, it returns black as dominant color)